### PR TITLE
refactor: switches interceptor routing to be global to all routes.

### DIFF
--- a/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/LambdaServer.kt
+++ b/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/LambdaServer.kt
@@ -87,7 +87,7 @@ abstract class LambdaServer<Request, Response>(
                 response.setStatusCode(HttpUtil.HTTP_NOT_FOUND)
 
             } else {
-                matched.forEach { route ->
+                for (route in matched) {
                     val request = buildRequest(event, route)
                     val exchange = LambdaHttpExchange(router, route, request, response, attributes)
                     val handler = route.handler ?: throw IllegalStateException("No route handler set for: $route")
@@ -99,6 +99,12 @@ abstract class LambdaServer<Request, Response>(
                     // check for exceptional route failure
                     exchange.failureCause?.let { cause ->
                         throw RuntimeException("Route failed: $route", cause)
+                    }
+                    if (exchange.shouldTriggerNextHandler) {
+                        logger.trace("Continuing to next handler (if exists) for: ${describeRequestShort(event)}")
+                    } else {
+                        logger.trace("Stopping processing for: ${describeRequestShort(event)}")
+                        break
                     }
                 }
             }

--- a/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/model/LambdaHttpExchange.kt
+++ b/adapter/awslambda/src/main/java/io/gatehill/imposter/awslambda/impl/model/LambdaHttpExchange.kt
@@ -44,7 +44,12 @@
 package io.gatehill.imposter.awslambda.impl.model
 
 import com.google.common.base.Strings
-import io.gatehill.imposter.http.*
+import io.gatehill.imposter.http.ExchangePhase
+import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.http.HttpRequest
+import io.gatehill.imposter.http.HttpResponse
+import io.gatehill.imposter.http.HttpRoute
+import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.util.HttpUtil
 import io.vertx.core.buffer.Buffer
 
@@ -66,6 +71,9 @@ class LambdaHttpExchange(
     override var phase = ExchangePhase.REQUEST_RECEIVED
 
     override var failureCause: Throwable? = null
+        private set
+
+    var shouldTriggerNextHandler = false
         private set
 
     override val response: HttpResponse = object : HttpResponse by response {
@@ -113,5 +121,9 @@ class LambdaHttpExchange(
 
     override fun put(key: String, value: Any) {
         attributes[key] = value
+    }
+
+    override fun next() {
+        shouldTriggerNextHandler = true
     }
 }

--- a/adapter/vertxweb/src/main/java/io/gatehill/imposter/server/vertxweb/impl/VertxHttpExchange.kt
+++ b/adapter/vertxweb/src/main/java/io/gatehill/imposter/server/vertxweb/impl/VertxHttpExchange.kt
@@ -100,4 +100,8 @@ class VertxHttpExchange(
     override fun put(key: String, value: Any) {
         routingContext.put(key, value)
     }
+
+    override fun next() {
+        routingContext.next()
+    }
 }

--- a/core/api/src/main/java/io/gatehill/imposter/http/ResponseBehaviourFactory.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/http/ResponseBehaviourFactory.kt
@@ -45,20 +45,38 @@ package io.gatehill.imposter.http
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.plugin.config.resource.ResponseConfig
 import io.gatehill.imposter.script.ReadWriteResponseBehaviour
+import io.gatehill.imposter.script.ResponseBehaviour
 
 /**
  * @author Pete Cornish
  */
 interface ResponseBehaviourFactory {
-    fun build(statusCode: Int, resourceConfig: BasicResourceConfig): ReadWriteResponseBehaviour
+    fun build(
+        statusCode: Int,
+        resourceConfig: BasicResourceConfig,
+        exchangeState: HttpExchangeState,
+    ): ReadWriteResponseBehaviour
 
     /**
      * Sets (but does not overwrite) values on the [io.gatehill.imposter.script.ResponseBehaviour], from
      * those on [ResponseConfig].
      *
      * @param statusCode the status code
-     * @param responseConfig
+     * @param resourceConfig
      * @param responseBehaviour
      */
-    fun populate(statusCode: Int, resourceConfig: BasicResourceConfig, responseBehaviour: ReadWriteResponseBehaviour)
+    fun populate(
+        statusCode: Int,
+        resourceConfig: BasicResourceConfig,
+        responseBehaviour: ReadWriteResponseBehaviour
+    )
+
+    /**
+     * Merge values from the source [ResponseBehaviour] (if they are set)
+     * on to the target [ResponseBehaviour].
+     */
+    fun merge(
+        source: ResponseBehaviour,
+        target: ReadWriteResponseBehaviour
+    )
 }

--- a/core/api/src/main/java/io/gatehill/imposter/model/HandlerType.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/model/HandlerType.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025.
+ *
+ * This file is part of Imposter.
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as
+ * defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights
+ * under the License will not include, and the License does not grant to
+ * you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all of
+ * the rights granted to you under the License to provide to third parties,
+ * for a fee or other consideration (including without limitation fees for
+ * hosting or consulting/support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from
+ * the functionality of the Software. Any license notice or attribution
+ * required by the License must also include this Commons Clause License
+ * Condition notice.
+ *
+ * Software: Imposter
+ *
+ * License: GNU Lesser General Public License version 3
+ *
+ * Licensor: Peter Cornish
+ *
+ * Imposter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Imposter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.gatehill.imposter.model
+
+/**
+ * Represents the type of handler.
+ */
+enum class HandlerType {
+    INTERCEPTOR,
+    RESOURCE,
+}

--- a/core/api/src/main/java/io/gatehill/imposter/plugin/config/ConfigurablePlugin.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/plugin/config/ConfigurablePlugin.kt
@@ -48,6 +48,6 @@ import io.gatehill.imposter.config.LoadedConfig
  * @author Pete Cornish
  */
 interface ConfigurablePlugin<C : PluginConfig> {
-    fun loadConfiguration(loadedConfigs: List<LoadedConfig>)
     val configs: List<C>
+    fun loadConfiguration(loadedConfigs: List<LoadedConfig>)
 }

--- a/core/api/src/main/java/io/gatehill/imposter/service/HandlerService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/HandlerService.kt
@@ -42,7 +42,6 @@
  */
 package io.gatehill.imposter.service
 
-import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpExchangeHandler
@@ -62,21 +61,19 @@ interface HandlerService {
      *
      * Example:
      * ```
-     * val handler = build(imposterConfig, allPluginConfigs, resourceMatcher) {
+     * val handler = build(allPluginConfigs, resourceMatcher) {
      *   // use httpExchange
      * }
      * router.get("/example").handler(handler)
      * ```
      *
-     * @param imposterConfig      the Imposter configuration
      * @param allPluginConfigs    all plugin configurations
      * @param resourceMatcher     the [ResourceMatcher] to use
-     * @param httpExchangeHandler the consumer of the [HttpExchange]
      * @param handlerType         the type of handler to build
+     * @param httpExchangeHandler the consumer of the [HttpExchange]
      * @return the handler
      */
     fun build(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType = HandlerType.RESOURCE,
@@ -87,7 +84,6 @@ interface HandlerService {
      * Same as [build] but wraps [httpExchangeHandler] in a future.
      */
     fun buildAndWrap(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType = HandlerType.RESOURCE,
@@ -99,20 +95,18 @@ interface HandlerService {
      *
      * Example:
      * ```
-     * val handler = build(imposterConfig, pluginConfig, resourceMatcher) {
+     * val handler = build(pluginConfig, resourceMatcher) {
      *   // use httpExchange
      * }
      * router.get("/example").handler(handler)
      * ```
      *
-     * @param imposterConfig      the Imposter configuration
      * @param pluginConfig        the plugin configuration
      * @param resourceMatcher     the [ResourceMatcher] to use
      * @param httpExchangeHandler the consumer of the [HttpExchange]
      * @return the handler
      */
     fun build(
-        imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType = HandlerType.RESOURCE,
@@ -120,7 +114,6 @@ interface HandlerService {
     ): HttpExchangeFutureHandler
 
     fun build(
-        imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceConfig: BasicResourceConfig,
         handlerType: HandlerType = HandlerType.RESOURCE,
@@ -131,7 +124,6 @@ interface HandlerService {
      * Same as [build] but wraps [httpExchangeHandler] in a future.
      */
     fun buildAndWrap(
-        imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType = HandlerType.RESOURCE,

--- a/core/api/src/main/java/io/gatehill/imposter/service/HandlerService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/HandlerService.kt
@@ -48,6 +48,7 @@ import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpExchangeHandler
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.ResourceMatcher
+import io.gatehill.imposter.model.HandlerType
 import io.gatehill.imposter.plugin.config.PluginConfig
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.server.ServerFactory
@@ -71,12 +72,14 @@ interface HandlerService {
      * @param allPluginConfigs    all plugin configurations
      * @param resourceMatcher     the [ResourceMatcher] to use
      * @param httpExchangeHandler the consumer of the [HttpExchange]
+     * @param handlerType         the type of handler to build
      * @return the handler
      */
     fun build(
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
+        handlerType: HandlerType = HandlerType.RESOURCE,
         httpExchangeHandler: HttpExchangeFutureHandler,
     ): HttpExchangeFutureHandler
 
@@ -87,6 +90,7 @@ interface HandlerService {
         imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
+        handlerType: HandlerType = HandlerType.RESOURCE,
         httpExchangeHandler: HttpExchangeHandler,
     ): HttpExchangeFutureHandler
 
@@ -111,6 +115,7 @@ interface HandlerService {
         imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
+        handlerType: HandlerType = HandlerType.RESOURCE,
         httpExchangeHandler: HttpExchangeFutureHandler,
     ): HttpExchangeFutureHandler
 
@@ -118,7 +123,8 @@ interface HandlerService {
         imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceConfig: BasicResourceConfig,
-        httpExchangeHandler: HttpExchangeFutureHandler
+        handlerType: HandlerType = HandlerType.RESOURCE,
+        httpExchangeHandler: HttpExchangeFutureHandler,
     ): HttpExchangeFutureHandler
 
     /**
@@ -128,6 +134,7 @@ interface HandlerService {
         imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
+        handlerType: HandlerType = HandlerType.RESOURCE,
         httpExchangeHandler: HttpExchangeHandler,
     ): HttpExchangeFutureHandler
 

--- a/core/api/src/main/java/io/gatehill/imposter/service/HandlerService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/HandlerService.kt
@@ -49,6 +49,7 @@ import io.gatehill.imposter.http.HttpExchangeHandler
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.http.ResourceMatcher
 import io.gatehill.imposter.plugin.config.PluginConfig
+import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.server.ServerFactory
 
 /**
@@ -111,6 +112,13 @@ interface HandlerService {
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         httpExchangeHandler: HttpExchangeFutureHandler,
+    ): HttpExchangeFutureHandler
+
+    fun build(
+        imposterConfig: ImposterConfig,
+        pluginConfig: PluginConfig,
+        resourceConfig: BasicResourceConfig,
+        httpExchangeHandler: HttpExchangeFutureHandler
     ): HttpExchangeFutureHandler
 
     /**

--- a/core/api/src/main/java/io/gatehill/imposter/service/InterceptorService.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/service/InterceptorService.kt
@@ -43,22 +43,17 @@
 
 package io.gatehill.imposter.service
 
-import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.plugin.config.PluginConfig
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
-import java.util.concurrent.CompletableFuture
 
 /**
  * Executes request interceptors.
  */
 interface InterceptorService {
-    /**
-     * Execute request interceptors, indicating whether the exchange
-     * has been handled.
-     */
-    fun executeInterceptors(
+    fun configureInterceptorRoute(
+        router: HttpRouter,
         pluginConfig: PluginConfig,
-        interceptors: List<BasicResourceConfig>,
-        httpExchange: HttpExchange,
-    ): CompletableFuture<Boolean>
+        interceptor: BasicResourceConfig
+    )
 }

--- a/core/api/src/main/java/io/gatehill/imposter/util/ResourceUtil.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/util/ResourceUtil.kt
@@ -57,6 +57,7 @@ object ResourceUtil {
     const val RC_LAST_HANDLER_TYPE = "handler.type"
     const val RESOURCE_CONFIG_KEY = "io.gatehill.imposter.resourceConfig"
     const val RC_REQUEST_ID_KEY = "request.id"
+    const val RC_RESPONSE_BEHAVIOUR = "response.behaviour"
     const val RC_SEND_NOT_FOUND_RESPONSE = "response.sendNotFoundResponse"
 
     /**

--- a/core/api/src/main/java/io/gatehill/imposter/util/ResourceUtil.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/util/ResourceUtil.kt
@@ -54,6 +54,7 @@ import java.util.regex.Pattern
  * @author Pete Cornish
  */
 object ResourceUtil {
+    const val RC_LAST_HANDLER_TYPE = "handler.type"
     const val RESOURCE_CONFIG_KEY = "io.gatehill.imposter.resourceConfig"
     const val RC_REQUEST_ID_KEY = "request.id"
     const val RC_SEND_NOT_FOUND_RESPONSE = "response.sendNotFoundResponse"

--- a/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
@@ -200,7 +200,6 @@ class Imposter(
             LOGGER.trace("Metrics enabled")
             router.route("/system/metrics").handler(
                 handlerService.build(
-                    imposterConfig,
                     allConfigs,
                     resourceMatcher,
                     httpExchangeHandler = serverFactory.createMetricsHandler()
@@ -210,7 +209,7 @@ class Imposter(
 
         // status check to indicate when server is up
         router.get("/system/status").handler(
-            handlerService.buildAndWrap(imposterConfig, allConfigs, resourceMatcher) { httpExchange ->
+            handlerService.buildAndWrap(allConfigs, resourceMatcher) { httpExchange ->
                 httpExchange.response
                     .putHeader(HttpUtil.CONTENT_TYPE, HttpUtil.CONTENT_TYPE_JSON)
                     .end(HttpUtil.buildStatusResponse())
@@ -221,7 +220,7 @@ class Imposter(
         plugins.filterIsInstance<RoutablePlugin>().forEach { it.configureRoutes(router) }
 
         // configure CORS after all routes have been added
-        corsService.configure(imposterConfig, allConfigs, router, resourceMatcher)
+        corsService.configure(allConfigs, router, resourceMatcher)
 
         // fire post route config hooks
         engineLifecycle.forEach { listener: EngineLifecycleListener ->

--- a/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/Imposter.kt
@@ -203,7 +203,7 @@ class Imposter(
                     imposterConfig,
                     allConfigs,
                     resourceMatcher,
-                    serverFactory.createMetricsHandler()
+                    httpExchangeHandler = serverFactory.createMetricsHandler()
                 )
             )
         }

--- a/core/engine/src/main/java/io/gatehill/imposter/model/steps/RemoteProcessingStep.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/model/steps/RemoteProcessingStep.kt
@@ -92,13 +92,13 @@ class RemoteProcessingStep(
             ctx.config.capture?.forEach { (key, config) ->
                 captureService.captureItem(key, config, remoteExchange, evaluators)
             }
-            responseBehaviourFactory.build(statusCode, ctx.resourceConfig)
+            responseBehaviourFactory.build(statusCode, ctx.resourceConfig, httpExchange)
         } catch (e: Exception) {
             logger.error("Error sending remote request: {} {}", ctx.config.method, ctx.config.url, e)
             val emptyResourceConfig = object : AbstractResourceConfig() {
                 override val responseConfig = ResponseConfig()
             }
-            responseBehaviourFactory.build(HttpUtil.HTTP_INTERNAL_ERROR, emptyResourceConfig)
+            responseBehaviourFactory.build(HttpUtil.HTTP_INTERNAL_ERROR, emptyResourceConfig, httpExchange)
         }
     }
 }

--- a/core/engine/src/main/java/io/gatehill/imposter/model/steps/http/RemoteHttpExchange.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/model/steps/http/RemoteHttpExchange.kt
@@ -99,4 +99,8 @@ class RemoteHttpExchange(
     override fun put(key: String, value: Any) {
         initiatingExchange.put(key, value)
     }
+
+    override fun next() {
+        throw UnsupportedOperationException()
+    }
 }

--- a/core/engine/src/main/java/io/gatehill/imposter/plugin/config/ConfiguredPlugin.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/plugin/config/ConfiguredPlugin.kt
@@ -119,12 +119,10 @@ abstract class ConfiguredPlugin<T : BasicPluginConfig> @Inject constructor(
         configureResourceRoutes(router)
     }
 
-    fun configureInterceptorRoutes(router: HttpRouter) {
-        configs.forEach { config ->
-            if (config is InterceptorsHolder<*>) {
-                config.interceptors?.forEach { interceptor ->
-                    interceptorService.configureInterceptorRoute(router, config, interceptor)
-                }
+    fun configureInterceptorRoutes(router: HttpRouter) = configs.forEach { config ->
+        if (config is InterceptorsHolder<*>) {
+            config.interceptors?.forEach { interceptor ->
+                interceptorService.configureInterceptorRoute(router, config, interceptor)
             }
         }
     }

--- a/core/engine/src/main/java/io/gatehill/imposter/service/HandlerServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/HandlerServiceImpl.kt
@@ -43,7 +43,6 @@
 package io.gatehill.imposter.service
 
 import com.google.common.collect.Lists
-import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.config.ResolvedResourceConfig
 import io.gatehill.imposter.config.util.EnvVars
 import io.gatehill.imposter.http.*
@@ -85,18 +84,16 @@ class HandlerServiceImpl @Inject constructor(
         EnvVars.getEnv("IMPOSTER_ADD_ENGINE_RESPONSE_HEADERS")?.toBoolean() != false
 
     override fun build(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType,
         httpExchangeHandler: HttpExchangeFutureHandler,
     ): HttpExchangeFutureHandler {
         val selectedConfig = securityService.findConfigPreferringSecurityPolicy(allPluginConfigs)
-        return build(imposterConfig, selectedConfig, resourceMatcher, handlerType, httpExchangeHandler)
+        return build(selectedConfig, resourceMatcher, handlerType, httpExchangeHandler)
     }
 
     override fun build(
-        imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType,
@@ -118,7 +115,6 @@ class HandlerServiceImpl @Inject constructor(
     }
 
     override fun build(
-        imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceConfig: BasicResourceConfig,
         handlerType: HandlerType,
@@ -140,22 +136,20 @@ class HandlerServiceImpl @Inject constructor(
     }
 
     override fun buildAndWrap(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType,
         httpExchangeHandler: HttpExchangeHandler,
     ): HttpExchangeFutureHandler =
-        build(imposterConfig, allPluginConfigs, resourceMatcher, handlerType, wrapInFuture(httpExchangeHandler))
+        build(allPluginConfigs, resourceMatcher, handlerType, wrapInFuture(httpExchangeHandler))
 
     override fun buildAndWrap(
-        imposterConfig: ImposterConfig,
         pluginConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         handlerType: HandlerType,
         httpExchangeHandler: HttpExchangeHandler,
     ): HttpExchangeFutureHandler =
-        build(imposterConfig, pluginConfig, resourceMatcher, handlerType, wrapInFuture(httpExchangeHandler))
+        build(pluginConfig, resourceMatcher, handlerType, wrapInFuture(httpExchangeHandler))
 
     /**
      * Wraps the given [httpExchangeHandler] in a [HttpExchangeFutureHandler] and returns the future.

--- a/core/engine/src/main/java/io/gatehill/imposter/service/InterceptorServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/InterceptorServiceImpl.kt
@@ -43,7 +43,6 @@
 
 package io.gatehill.imposter.service
 
-import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.http.HttpRouter
 import io.gatehill.imposter.model.HandlerType
@@ -67,7 +66,6 @@ import javax.inject.Inject
 class InterceptorServiceImpl @Inject constructor(
     private val handlerService: HandlerService,
     private val responseRoutingService: ResponseRoutingService,
-    private val imposterConfig: ImposterConfig,
 ) : InterceptorService, CoroutineScope by supervisedDefaultCoroutineScope {
 
     override fun configureInterceptorRoute(
@@ -76,7 +74,6 @@ class InterceptorServiceImpl @Inject constructor(
         interceptor: BasicResourceConfig,
     ) {
         val routeHandler = handlerService.build(
-            imposterConfig,
             pluginConfig,
             interceptor,
             handlerType = HandlerType.INTERCEPTOR

--- a/core/engine/src/main/java/io/gatehill/imposter/service/InterceptorServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/InterceptorServiceImpl.kt
@@ -46,6 +46,7 @@ package io.gatehill.imposter.service
 import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.http.HttpRouter
+import io.gatehill.imposter.model.HandlerType
 import io.gatehill.imposter.plugin.config.PluginConfig
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.script.ResponseBehaviourType
@@ -74,7 +75,12 @@ class InterceptorServiceImpl @Inject constructor(
         pluginConfig: PluginConfig,
         interceptor: BasicResourceConfig,
     ) {
-        val routeHandler = handlerService.build(imposterConfig, pluginConfig, interceptor) { exchange ->
+        val routeHandler = handlerService.build(
+            imposterConfig,
+            pluginConfig,
+            interceptor,
+            handlerType = HandlerType.INTERCEPTOR
+        ) { exchange ->
             future {
                 val handler = buildHandler(exchange)
                 responseRoutingService.route(

--- a/core/engine/src/main/java/io/gatehill/imposter/service/security/CorsService.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/security/CorsService.kt
@@ -43,7 +43,6 @@
 
 package io.gatehill.imposter.service.security
 
-import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.http.HttpExchangeFutureHandler
 import io.gatehill.imposter.http.HttpMethod
@@ -70,7 +69,6 @@ class CorsService @Inject constructor(
     private val logger = LogManager.getLogger(CorsService::class.java)
 
     fun configure(
-        imposterConfig: ImposterConfig,
         allConfigs: List<PluginConfig>,
         router: HttpRouter,
         resourceMatcher: ResourceMatcher,
@@ -85,7 +83,7 @@ class CorsService @Inject constructor(
 
             // preflight
             router.route(HttpMethod.OPTIONS, "/*").handler(
-                handlePreflight(imposterConfig, selectedConfig, resourceMatcher, cors)
+                handlePreflight(selectedConfig, resourceMatcher, cors)
             )
 
             // request already handled
@@ -97,12 +95,11 @@ class CorsService @Inject constructor(
     }
     
     private fun handlePreflight(
-        imposterConfig: ImposterConfig,
         selectedConfig: PluginConfig,
         resourceMatcher: ResourceMatcher,
         cors: CorsConfig,
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, selectedConfig, resourceMatcher) { exchange: HttpExchange ->
+        return handlerService.buildAndWrap(selectedConfig, resourceMatcher) { exchange: HttpExchange ->
             val origin = determineResponseOrigin(cors, exchange.request)
             origin?.let {
                 logger.debug("Serving CORS pre-flight request: ${LogUtil.describeRequest(exchange)}")

--- a/core/http/src/main/java/io/gatehill/imposter/http/HttpExchange.kt
+++ b/core/http/src/main/java/io/gatehill/imposter/http/HttpExchange.kt
@@ -45,7 +45,7 @@ package io.gatehill.imposter.http
 /**
  * @author Pete Cornish
  */
-interface HttpExchange {
+interface HttpExchange : HttpExchangeState {
     var phase: ExchangePhase
     val request: HttpRequest
     val response: HttpResponse
@@ -61,24 +61,6 @@ interface HttpExchange {
     fun fail(statusCode: Int)
     fun fail(statusCode: Int, cause: Throwable?)
     val failureCause: Throwable?
-
-    fun <T> get(key: String): T?
-    fun put(key: String, value: Any)
-
-    fun <T : Any> getOrPut(key: String, defaultSupplier: () -> T): T {
-        return get(key) ?: run {
-            val value = defaultSupplier()
-            put(key, value)
-            return@run value
-        }
-    }
-
-    /**
-     * Like [getOrPut] but returns [Unit].
-     */
-    fun <T: Any> putIfAbsent(key: String, supplier: () -> T) {
-        getOrPut(key, supplier)
-    }
 
     fun next()
 }

--- a/core/http/src/main/java/io/gatehill/imposter/http/HttpExchange.kt
+++ b/core/http/src/main/java/io/gatehill/imposter/http/HttpExchange.kt
@@ -72,4 +72,13 @@ interface HttpExchange {
             return@run value
         }
     }
+
+    /**
+     * Like [getOrPut] but returns [Unit].
+     */
+    fun <T: Any> putIfAbsent(key: String, supplier: () -> T) {
+        getOrPut(key, supplier)
+    }
+
+    fun next()
 }

--- a/core/http/src/main/java/io/gatehill/imposter/http/HttpExchangeState.kt
+++ b/core/http/src/main/java/io/gatehill/imposter/http/HttpExchangeState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021.
+ * Copyright (c) 2025.
  *
  * This file is part of Imposter.
  *
@@ -40,41 +40,27 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
  */
-package io.gatehill.imposter.plugin.openapi.http
 
-import com.google.common.base.Strings
-import io.gatehill.imposter.http.DefaultResponseBehaviourFactory
-import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
-import io.gatehill.imposter.plugin.openapi.config.OpenApiResponseConfig
-import io.gatehill.imposter.script.ReadWriteResponseBehaviour
-import io.gatehill.imposter.script.ResponseBehaviour
+package io.gatehill.imposter.http
 
 /**
- * Extends base response behaviour population with specific
- * OpenAPI plugin configuration.
- *
- * @author Pete Cornish
+ * Holds state for an HTTP exchange.
  */
-class OpenApiResponseBehaviourFactory : DefaultResponseBehaviourFactory() {
-    override fun populate(
-        statusCode: Int,
-        resourceConfig: BasicResourceConfig,
-        responseBehaviour: ReadWriteResponseBehaviour
-    ) {
-        super.populate(statusCode, resourceConfig, responseBehaviour)
-        val configExampleName = (resourceConfig.responseConfig as OpenApiResponseConfig).exampleName
-        if (Strings.isNullOrEmpty(responseBehaviour.exampleName) && !Strings.isNullOrEmpty(configExampleName)) {
-            responseBehaviour.withExampleName(configExampleName!!)
-        }
+interface HttpExchangeState {
+    fun <T> get(key: String): T?
+
+    fun put(key: String, value: Any)
+
+    fun <T : Any> getOrPut(key: String, defaultSupplier: () -> T): T = get(key) ?: run {
+        val value = defaultSupplier()
+        put(key, value)
+        return@run value
     }
 
-    override fun merge(
-        source: ResponseBehaviour,
-        target: ReadWriteResponseBehaviour
-    ) {
-        super.merge(source, target)
-        if (!Strings.isNullOrEmpty(source.exampleName)) {
-            target.withExampleName(source.exampleName!!)
-        }
+    /**
+     * Like [getOrPut] but returns [Unit].
+     */
+    fun <T: Any> putIfAbsent(key: String, supplier: () -> T) {
+        getOrPut(key, supplier)
     }
 }

--- a/mock/hbase/src/main/java/io/gatehill/imposter/plugin/hbase/HBasePluginImpl.kt
+++ b/mock/hbase/src/main/java/io/gatehill/imposter/plugin/hbase/HBasePluginImpl.kt
@@ -133,7 +133,7 @@ class HBasePluginImpl @Inject constructor(
      */
     private fun addRowRetrievalRoute(pluginConfig: PluginConfig, router: HttpRouter, path: String) {
         router.get("$path/{tableName}/{recordId}/").handler(
-            handlerService.build(imposterConfig, pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.build(pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
                 val request = httpExchange.request
                 val tableName = request.getPathParam("tableName")!!
                 val recordId = request.getPathParam("recordId")!!
@@ -191,7 +191,7 @@ class HBasePluginImpl @Inject constructor(
      */
     private fun addCreateScannerRoute(pluginConfig: PluginConfig, router: HttpRouter, path: String) {
         router.post("$path/{tableName}/scanner").handler(
-            handlerService.build(imposterConfig, pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.build(pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
                 val tableName = httpExchange.request.getPathParam("tableName")!!
 
                 // check that the table is registered
@@ -257,7 +257,7 @@ class HBasePluginImpl @Inject constructor(
      */
     private fun addReadScannerResultsRoute(pluginConfig: HBasePluginConfig, router: HttpRouter, path: String) {
         router.get("$path/{tableName}/scanner/{scannerId}").handler(
-            handlerService.build(imposterConfig, pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.build(pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
                 val request = httpExchange.request
                 val tableName = request.getPathParam("tableName")!!
                 val scannerId = request.getPathParam("scannerId")!!

--- a/mock/hbase/src/main/java/io/gatehill/imposter/plugin/hbase/HBasePluginImpl.kt
+++ b/mock/hbase/src/main/java/io/gatehill/imposter/plugin/hbase/HBasePluginImpl.kt
@@ -61,6 +61,7 @@ import io.gatehill.imposter.plugin.hbase.service.ScannerService
 import io.gatehill.imposter.plugin.hbase.service.serialisation.DeserialisationService
 import io.gatehill.imposter.plugin.hbase.service.serialisation.SerialisationService
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseFileService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.util.FileUtil.findRow
@@ -85,11 +86,12 @@ class HBasePluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     private val handlerService: HandlerService,
+    interceptorService: InterceptorService,
     private val responseFileService: ResponseFileService,
     private val responseRoutingService: ResponseRoutingService,
     private val scannerService: ScannerService,
 ) : ConfiguredPlugin<HBasePluginConfig>(
-    vertx, imposterConfig
+    vertx, imposterConfig, interceptorService
 ) {
     override val configClass = HBasePluginConfig::class.java
     private var tables: Map<String, HBasePluginConfig>? = null
@@ -105,7 +107,7 @@ class HBasePluginImpl @Inject constructor(
         tables = configs.associateBy { it.tableName }
     }
 
-    override fun configureRoutes(router: HttpRouter) {
+    override fun configureResourceRoutes(router: HttpRouter) {
         // add route for each distinct path
         tableConfigs.values.map { config: HBasePluginConfig -> ConfigAndPath(config, config.path ?: "") }
             .distinct()

--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
@@ -193,12 +193,12 @@ class OpenApiPluginImpl @Inject constructor(
     private fun exposeSpec(router: HttpRouter) {
         LOGGER.debug("Adding specification UI at: {}{}", imposterConfig.serverUrl, specPathPrefix)
         router.get(combinedSpecPath).handler(
-                handlerService.build(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
+                handlerService.build(configs, resourceMatcher) { httpExchange: HttpExchange ->
                     handleCombinedSpec(httpExchange)
                 }
         )
         router.getWithRegex("$specPathPrefix$").handler(
-                handlerService.buildAndWrap(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
+                handlerService.buildAndWrap(configs, resourceMatcher) { httpExchange: HttpExchange ->
                     httpExchange.response
                             .putHeader("Location", "$specPathPrefix/")
                             .setStatusCode(HttpUtil.HTTP_MOVED_PERM)
@@ -290,7 +290,7 @@ class OpenApiPluginImpl @Inject constructor(
     ): HttpExchangeFutureHandler {
         // statically calculate as much as possible
         val statusCodeFactory = buildStatusCodeCalculator(operation)
-        return handlerService.build(imposterConfig, pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.build(pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
             LOGGER.trace("Operation ${operation.operationId} matched for request: ${describeRequestShort(httpExchange)}")
 
             if (!specificationService.isValidRequest(pluginConfig, httpExchange, allSpecs)) {
@@ -313,7 +313,6 @@ class OpenApiPluginImpl @Inject constructor(
                         }
 
                         exampleService.serveExample(
-                            imposterConfig,
                             pluginConfig,
                             httpExchange,
                             responseBehaviour,

--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/OpenApiPluginImpl.kt
@@ -64,6 +64,7 @@ import io.gatehill.imposter.script.ResponseBehaviour
 import io.gatehill.imposter.server.ServerFactory
 import io.gatehill.imposter.service.DefaultBehaviourHandler
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
 import io.gatehill.imposter.service.ResponseService.ResponseSender
@@ -83,9 +84,6 @@ import io.vertx.core.Vertx
 import org.apache.logging.log4j.LogManager
 import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.set
 
 /**
  * Plugin for OpenAPI (OAI; formerly known as 'Swagger').
@@ -98,6 +96,7 @@ class OpenApiPluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     private val handlerService: HandlerService,
+    interceptorService: InterceptorService,
     private val specificationService: SpecificationService,
     private val exampleService: ExampleService,
     private val responseService: ResponseService,
@@ -106,7 +105,7 @@ class OpenApiPluginImpl @Inject constructor(
     private val serverFactory: ServerFactory,
     private val specificationLoaderService: SpecificationLoaderService,
 ) : ConfiguredPlugin<OpenApiPluginConfig>(
-    vertx, imposterConfig
+    vertx, imposterConfig, interceptorService
 ) {
     override val configClass = OpenApiPluginConfig::class.java
     private lateinit var allSpecs: List<ParsedSpec>
@@ -135,7 +134,7 @@ class OpenApiPluginImpl @Inject constructor(
 
     private val resourceMatcher = SingletonResourceMatcher.instance
 
-    override fun configureRoutes(router: HttpRouter) {
+    override fun configureResourceRoutes(router: HttpRouter) {
         if (configs.isEmpty()) {
             LOGGER.debug("No OpenAPI configuration files provided - skipping plugin setup")
             return

--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/ExampleService.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/ExampleService.kt
@@ -42,7 +42,6 @@
  */
 package io.gatehill.imposter.plugin.openapi.service
 
-import io.gatehill.imposter.ImposterConfig
 import io.gatehill.imposter.http.HttpExchange
 import io.gatehill.imposter.plugin.openapi.config.OpenApiPluginConfig
 import io.gatehill.imposter.script.ResponseBehaviour
@@ -56,7 +55,6 @@ interface ExampleService {
     /**
      * Attempt to respond with an example from the API specification.
      *
-     * @param imposterConfig    the Imposter engine configuration
      * @param config            the plugin configuration
      * @param httpExchange    the HTTP exchange
      * @param responseBehaviour the response behaviour
@@ -65,7 +63,6 @@ interface ExampleService {
      * @return `true` if an example was served, otherwise `false`
      */
     fun serveExample(
-        imposterConfig: ImposterConfig,
         config: OpenApiPluginConfig,
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,

--- a/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/ExampleServiceImpl.kt
+++ b/mock/openapi/src/main/java/io/gatehill/imposter/plugin/openapi/service/ExampleServiceImpl.kt
@@ -69,14 +69,14 @@ import javax.inject.Inject
  */
 class ExampleServiceImpl @Inject constructor(
     private val schemaService: SchemaService,
-    private val responseTransmissionService: ResponseTransmissionService
+    private val responseTransmissionService: ResponseTransmissionService,
+    private val imposterConfig: ImposterConfig,
 ) : ExampleService {
 
     /**
      * {@inheritDoc}
      */
     override fun serveExample(
-        imposterConfig: ImposterConfig,
         config: OpenApiPluginConfig,
         httpExchange: HttpExchange,
         responseBehaviour: ResponseBehaviour,

--- a/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
+++ b/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
@@ -57,6 +57,7 @@ import io.gatehill.imposter.plugin.rest.config.RestPluginConfig
 import io.gatehill.imposter.plugin.rest.config.RestPluginResourceConfig
 import io.gatehill.imposter.script.ResponseBehaviour
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseFileService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
@@ -80,17 +81,18 @@ open class RestPluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     private val handlerService: HandlerService,
+    private val interceptorService: InterceptorService,
     private val responseFileService: ResponseFileService,
     private val responseService: ResponseService,
     private val responseRoutingService: ResponseRoutingService,
 ) : ConfiguredPlugin<RestPluginConfig>(
-    vertx, imposterConfig
+    vertx, imposterConfig, interceptorService
 ) {
     override val configClass = RestPluginConfig::class.java
 
     private val resourceMatcher = SingletonResourceMatcher.instance
 
-    override fun configureRoutes(router: HttpRouter) {
+    override fun configureResourceRoutes(router: HttpRouter) {
         configs.forEach { config: RestPluginConfig ->
             if (config.path.isNullOrEmpty() && config.responseConfig.hasConfiguration()) {
                 // The REST plugin treats an undefined root path as equivalent to

--- a/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
+++ b/mock/rest/src/main/java/io/gatehill/imposter/plugin/rest/RestPluginImpl.kt
@@ -126,7 +126,7 @@ open class RestPluginImpl @Inject constructor(
         LOGGER.debug("Adding handler: {} -> {}", method, normalisedPath)
 
         router.route(method, normalisedPath).handler(
-            handlerService.build(imposterConfig, pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.build(pluginConfig, resourceMatcher) { httpExchange: HttpExchange ->
                 val resourceConfig = httpExchange.get<ContentTypedConfig>(ResourceUtil.RESOURCE_CONFIG_KEY)!!
 
                 responseRoutingService.route(pluginConfig, resourceConfig, httpExchange) { responseBehaviour ->

--- a/mock/sfdc/src/main/java/io/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.kt
+++ b/mock/sfdc/src/main/java/io/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.kt
@@ -91,7 +91,7 @@ class SfdcPluginImpl @Inject constructor(
     override fun configureResourceRoutes(router: HttpRouter) {
         // oauth handler
         router.post("/services/oauth2/token").handler(
-            handlerService.buildAndWrap(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.buildAndWrap(configs, resourceMatcher) { httpExchange: HttpExchange ->
                 LOGGER.info("Handling oauth request: {}", httpExchange.request.bodyAsString)
                 val authResponse = JsonObject()
                 authResponse.put("access_token", "dummyAccessToken")
@@ -103,7 +103,7 @@ class SfdcPluginImpl @Inject constructor(
 
         // query handler
         router.get("/services/data/{apiVersion}/query/").handler(
-            handlerService.build(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.build(configs, resourceMatcher) { httpExchange: HttpExchange ->
                 val request = httpExchange.request
                 val apiVersion = request.getPathParam("apiVersion")!!
 
@@ -142,7 +142,7 @@ class SfdcPluginImpl @Inject constructor(
 
         // get SObject handler
         configs.forEach { config: SfdcPluginConfig ->
-            val handler = handlerService.build(imposterConfig, config, resourceMatcher) { httpExchange: HttpExchange ->
+            val handler = handlerService.build(config, resourceMatcher) { httpExchange: HttpExchange ->
                 // script should fire first
                 responseRoutingService.route(config, httpExchange) { responseBehaviour ->
                     makeFuture {
@@ -177,7 +177,7 @@ class SfdcPluginImpl @Inject constructor(
 
         // create SObject handler
         router.post("/services/data/{apiVersion}/sobjects/{sObjectName}").handler(
-            handlerService.buildAndWrap(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.buildAndWrap(configs, resourceMatcher) { httpExchange: HttpExchange ->
                 val request = httpExchange.request
                 val sObjectName = request.getPathParam("sObjectName")
                 val sObject = request.bodyAsJson
@@ -205,7 +205,7 @@ class SfdcPluginImpl @Inject constructor(
      * @return
      */
     private fun handleUpdateRequest(): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(configs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val sObjectName = request.getPathParam("sObjectName")
             val sObjectId = request.getPathParam("sObjectId")

--- a/mock/sfdc/src/main/java/io/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.kt
+++ b/mock/sfdc/src/main/java/io/gatehill/imposter/plugin/sfdc/SfdcPluginImpl.kt
@@ -52,6 +52,7 @@ import io.gatehill.imposter.plugin.PluginInfo
 import io.gatehill.imposter.plugin.config.ConfiguredPlugin
 import io.gatehill.imposter.plugin.sfdc.config.SfdcPluginConfig
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseFileService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.util.FileUtil.findRow
@@ -63,8 +64,7 @@ import io.vertx.core.Vertx
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.json.JsonObject
 import org.apache.logging.log4j.LogManager
-import java.util.StringTokenizer
-import java.util.UUID
+import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -78,16 +78,17 @@ class SfdcPluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     private val handlerService: HandlerService,
+    interceptorService: InterceptorService,
     private val responseFileService: ResponseFileService,
     private val responseRoutingService: ResponseRoutingService,
 ) : ConfiguredPlugin<SfdcPluginConfig>(
-    vertx, imposterConfig
+    vertx, imposterConfig, interceptorService
 ) {
     override val configClass = SfdcPluginConfig::class.java
 
     private val resourceMatcher = SingletonResourceMatcher.instance
 
-    override fun configureRoutes(router: HttpRouter) {
+    override fun configureResourceRoutes(router: HttpRouter) {
         // oauth handler
         router.post("/services/oauth2/token").handler(
             handlerService.buildAndWrap(imposterConfig, configs, resourceMatcher) { httpExchange: HttpExchange ->

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/SoapPluginImpl.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/SoapPluginImpl.kt
@@ -68,6 +68,7 @@ import io.gatehill.imposter.plugin.soap.util.SoapUtil
 import io.gatehill.imposter.script.ResponseBehaviour
 import io.gatehill.imposter.service.DefaultBehaviourHandler
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
 import io.gatehill.imposter.service.ResponseService.ResponseSender
@@ -80,7 +81,6 @@ import org.apache.logging.log4j.LogManager
 import java.io.File
 import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
-import kotlin.collections.set
 
 /**
  * Plugin for SOAP.
@@ -93,12 +93,13 @@ class SoapPluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     private val handlerService: HandlerService,
+    interceptorService: InterceptorService,
     private val responseService: ResponseService,
     private val responseRoutingService: ResponseRoutingService,
     private val soapExampleService: SoapExampleService,
     private val soapResponseBehaviourFactory: SoapResponseBehaviourFactory,
 ) : ConfiguredPlugin<SoapPluginConfig>(
-    vertx, imposterConfig
+    vertx, imposterConfig, interceptorService
 ) {
     override val configClass = SoapPluginConfig::class.java
 
@@ -106,7 +107,7 @@ class SoapPluginImpl @Inject constructor(
         private val LOGGER = LogManager.getLogger(SoapPluginImpl::class.java)
     }
 
-    override fun configureRoutes(router: HttpRouter) {
+    override fun configureResourceRoutes(router: HttpRouter) {
         if (configs.isEmpty()) {
             LOGGER.debug("No WSDL configuration files provided - skipping plugin setup")
             return

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/SoapPluginImpl.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/SoapPluginImpl.kt
@@ -167,7 +167,7 @@ class SoapPluginImpl @Inject constructor(
 
         // TODO parse HTTP binding to check for other verbs
         router.route(HttpMethod.POST, fullPath).handler(
-            handlerService.build(imposterConfig, config, soapResourceMatcher) { httpExchange: HttpExchange ->
+            handlerService.build(config, soapResourceMatcher) { httpExchange: HttpExchange ->
                 val bodyHolder: MessageBodyHolder = when (binding.type) {
                     BindingType.SOAP, BindingType.HTTP -> {
                         httpExchange.request.body?.let { body -> SoapUtil.parseBody(config, body) } ?: run {

--- a/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/http/SoapResponseBehaviourFactory.kt
+++ b/mock/soap/src/main/java/io/gatehill/imposter/plugin/soap/http/SoapResponseBehaviourFactory.kt
@@ -46,6 +46,7 @@ import io.gatehill.imposter.http.DefaultResponseBehaviourFactory
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.plugin.soap.config.SoapResponseConfig
 import io.gatehill.imposter.script.ReadWriteResponseBehaviour
+import io.gatehill.imposter.script.ResponseBehaviour
 
 /**
  * Extends base response behaviour population with specific
@@ -66,5 +67,15 @@ class SoapResponseBehaviourFactory : DefaultResponseBehaviourFactory() {
         // invoke superclass after calling `withSoapFault` as it
         // overrides the status code to 500
         super.populate(statusCode, resourceConfig, responseBehaviour)
+    }
+
+    override fun merge(
+        source: ResponseBehaviour,
+        target: ReadWriteResponseBehaviour
+    ) {
+        super.merge(source, target)
+        if (source.soapFault) {
+            target.withSoapFault()
+        }
     }
 }

--- a/mock/wiremock/src/main/java/io/gatehill/imposter/plugin/wiremock/WiremockPluginImpl.kt
+++ b/mock/wiremock/src/main/java/io/gatehill/imposter/plugin/wiremock/WiremockPluginImpl.kt
@@ -56,6 +56,7 @@ import io.gatehill.imposter.plugin.wiremock.model.WiremockFile
 import io.gatehill.imposter.plugin.wiremock.model.WiremockMapping
 import io.gatehill.imposter.plugin.wiremock.util.ConversionUtil
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseFileService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
@@ -80,6 +81,7 @@ class WiremockPluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     handlerService: HandlerService,
+    interceptorService: InterceptorService,
     responseFileService: ResponseFileService,
     responseService: ResponseService,
     responseRoutingService: ResponseRoutingService,
@@ -87,6 +89,7 @@ class WiremockPluginImpl @Inject constructor(
     vertx,
     imposterConfig,
     handlerService,
+    interceptorService,
     responseFileService,
     responseService,
     responseRoutingService,

--- a/mock/wiremock/src/test/java/io/gatehill/imposter/plugin/wiremock/WiremockPluginTest.kt
+++ b/mock/wiremock/src/test/java/io/gatehill/imposter/plugin/wiremock/WiremockPluginTest.kt
@@ -48,6 +48,7 @@ import io.gatehill.imposter.config.ConfigReference
 import io.gatehill.imposter.config.LoadedConfig
 import io.gatehill.imposter.config.util.EnvVars
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseFileService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
@@ -152,6 +153,7 @@ class WiremockPluginTest {
             mock<Vertx>(),
             ImposterConfig(),
             mock<HandlerService>(),
+            mock<InterceptorService>(),
             mock<ResponseFileService>(),
             mock<ResponseService>(),
             mock<ResponseRoutingService>()

--- a/server/src/test/java/io/gatehill/imposter/plugin/test/TestPluginImpl.kt
+++ b/server/src/test/java/io/gatehill/imposter/plugin/test/TestPluginImpl.kt
@@ -84,7 +84,7 @@ class TestPluginImpl @Inject constructor(
         uniqueRoute: UniqueRoute,
     ) {
         logger.info("Configuring route: $uniqueRoute")
-        val handler = handlerService.build(imposterConfig, pluginConfig, resourceMatcher) { httpExchange ->
+        val handler = handlerService.build(pluginConfig, resourceMatcher) { httpExchange ->
             val resourceConfig = httpExchange.get<BasicResourceConfig>(ResourceUtil.RESOURCE_CONFIG_KEY)!!
 
             responseRoutingService.route(pluginConfig, resourceConfig, httpExchange) { responseBehaviour ->

--- a/server/src/test/java/io/gatehill/imposter/plugin/test/TestPluginImpl.kt
+++ b/server/src/test/java/io/gatehill/imposter/plugin/test/TestPluginImpl.kt
@@ -49,6 +49,7 @@ import io.gatehill.imposter.http.UniqueRoute
 import io.gatehill.imposter.plugin.config.ConfiguredPlugin
 import io.gatehill.imposter.plugin.config.resource.BasicResourceConfig
 import io.gatehill.imposter.service.HandlerService
+import io.gatehill.imposter.service.InterceptorService
 import io.gatehill.imposter.service.ResponseRoutingService
 import io.gatehill.imposter.service.ResponseService
 import io.gatehill.imposter.util.ResourceUtil
@@ -64,15 +65,16 @@ class TestPluginImpl @Inject constructor(
     vertx: Vertx,
     imposterConfig: ImposterConfig,
     private val handlerService: HandlerService,
+    interceptorService: InterceptorService,
     private val responseService: ResponseService,
     private val responseRoutingService: ResponseRoutingService,
-) : ConfiguredPlugin<TestPluginConfig>(vertx, imposterConfig) {
+) : ConfiguredPlugin<TestPluginConfig>(vertx, imposterConfig, interceptorService) {
     private val logger: Logger = LogManager.getLogger(TestPluginImpl::class.java)
     override val configClass = TestPluginConfig::class.java
 
     private val resourceMatcher = SingletonResourceMatcher.instance
 
-    override fun configureRoutes(router: HttpRouter) {
+    override fun configureResourceRoutes(router: HttpRouter) {
         findUniqueRoutes().forEach { (route, config) -> configureRoute(config, router, route) }
     }
 

--- a/server/src/test/java/io/gatehill/imposter/server/InterceptorTest.kt
+++ b/server/src/test/java/io/gatehill/imposter/server/InterceptorTest.kt
@@ -89,11 +89,21 @@ class InterceptorTest : BaseVerticleTest() {
     }
 
     @Test
-    fun `interceptors should be skipped`() {
+    fun `no matching interceptor`() {
+        RestAssured.given().`when`()
+            .get("/no-interceptor-match")
+            .then()
+            .statusCode(200)
+            .body(equalTo("default"))
+    }
+
+    @Test
+    fun `interceptor has same path as resource`() {
         RestAssured.given().`when`()
             .get("/example")
             .then()
             .statusCode(200)
-            .body(equalTo("default"))
+            .body(equalTo("example"))
+            .header("X-Interceptor", "example")
     }
 }

--- a/server/src/test/resources/interceptor/test-plugin-config.yaml
+++ b/server/src/test/resources/interceptor/test-plugin-config.yaml
@@ -16,7 +16,18 @@ interceptors:
         var req = stores.open("request");
         req.save("response", "passthrough");
 
+- path: /example
+  continue: true
+  response:
+    headers:
+      X-Interceptor: "example"
+
 resources:
+- path: /example
+  method: GET
+  response:
+    content: "example"
+
 - path: /*
   method: GET
   response:

--- a/store/common/src/main/java/io/gatehill/imposter/store/service/StoreRestApiServiceImpl.kt
+++ b/store/common/src/main/java/io/gatehill/imposter/store/service/StoreRestApiServiceImpl.kt
@@ -57,7 +57,7 @@ import io.gatehill.imposter.store.factory.StoreFactory
 import io.gatehill.imposter.util.HttpUtil
 import io.gatehill.imposter.util.MapUtil
 import org.apache.logging.log4j.LogManager
-import java.util.Objects
+import java.util.*
 import javax.inject.Inject
 
 /**
@@ -82,19 +82,18 @@ class StoreRestApiServiceImpl @Inject constructor(
         allPluginConfigs: List<PluginConfig>,
         router: HttpRouter
     ) {
-        router.get("/system/store/{storeName}").handler(handleLoadAll(imposterConfig, allPluginConfigs))
-        router.delete("/system/store/{storeName}").handler(handleDeleteStore(imposterConfig, allPluginConfigs))
-        router.get("/system/store/{storeName}/{key}").handler(handleLoadSingle(imposterConfig, allPluginConfigs))
-        router.put("/system/store/{storeName}/{key}").handler(handleSaveSingle(imposterConfig, allPluginConfigs))
-        router.post("/system/store/{storeName}").handler(handleSaveMultiple(imposterConfig, allPluginConfigs))
-        router.delete("/system/store/{storeName}/{key}").handler(handleDeleteSingle(imposterConfig, allPluginConfigs))
+        router.get("/system/store/{storeName}").handler(handleLoadAll(allPluginConfigs))
+        router.delete("/system/store/{storeName}").handler(handleDeleteStore(allPluginConfigs))
+        router.get("/system/store/{storeName}/{key}").handler(handleLoadSingle(allPluginConfigs))
+        router.put("/system/store/{storeName}/{key}").handler(handleSaveSingle(allPluginConfigs))
+        router.post("/system/store/{storeName}").handler(handleSaveMultiple(allPluginConfigs))
+        router.delete("/system/store/{storeName}/{key}").handler(handleDeleteSingle(allPluginConfigs))
     }
 
     private fun handleLoadAll(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
@@ -124,10 +123,9 @@ class StoreRestApiServiceImpl @Inject constructor(
     }
 
     private fun handleDeleteStore(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val storeName = httpExchange.request.getPathParam("storeName")!!
             storeFactory.clearStore(storeName, ephemeral = false)
             LOGGER.debug("Deleted store: {}", storeName)
@@ -139,10 +137,9 @@ class StoreRestApiServiceImpl @Inject constructor(
     }
 
     private fun handleLoadSingle(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
@@ -172,10 +169,9 @@ class StoreRestApiServiceImpl @Inject constructor(
     }
 
     private fun handleSaveSingle(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
@@ -201,10 +197,9 @@ class StoreRestApiServiceImpl @Inject constructor(
     }
 
     private fun handleSaveMultiple(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)
@@ -224,10 +219,9 @@ class StoreRestApiServiceImpl @Inject constructor(
     }
 
     private fun handleDeleteSingle(
-        imposterConfig: ImposterConfig,
         allPluginConfigs: List<PluginConfig>
     ): HttpExchangeFutureHandler {
-        return handlerService.buildAndWrap(imposterConfig, allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
+        return handlerService.buildAndWrap(allPluginConfigs, resourceMatcher) { httpExchange: HttpExchange ->
             val request = httpExchange.request
             val storeName = request.getPathParam("storeName")!!
             val store = openStore(storeName)


### PR DESCRIPTION
Interceptor execution shouldn't depend on an existing matching resource route.