### PR TITLE
feature/707: improve soap 1.1 capture of proxy request/responses

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Main-Class: io.gatehill.imposter.cmd.ImposterLauncher
+Imposter-Version: 0.0.0-SNAPSHOT
+Multi-Release: true
+

--- a/cmd/src/main/java/io/gatehill/imposter/cmd/ImposterLauncher.kt
+++ b/cmd/src/main/java/io/gatehill/imposter/cmd/ImposterLauncher.kt
@@ -117,6 +117,9 @@ class ImposterLauncher(args: Array<String>) {
 
     @Option(name = "--serverFactory", usage = "Fully qualified class for server factory")
     private var serverFactory: String = VertxWebServerFactoryImpl::class.java.canonicalName
+    
+    @Option(name = "--soap", usage = "Enable SOAP-aware mode for capturing requests/responses with SOAPAction")
+    private var soapMode: Boolean = false
 
     companion object {
         private val LOGGER = LogManager.getLogger(ImposterLauncher::class.java)
@@ -204,6 +207,11 @@ class ImposterLauncher(args: Array<String>) {
             imposterConfig.configDirs = configDirs
             imposterConfig.plugins = plugins
             imposterConfig.pluginArgs = splitArgs
+            imposterConfig.soapMode = soapMode
+            
+            if (soapMode) {
+                LOGGER.info("SOAP-aware mode enabled - requests and responses will be saved with SOAPAction-based filenames")
+            }
         }
 
         LifecycleAwareLauncher().dispatch(originalArgs)

--- a/core/api/src/main/java/io/gatehill/imposter/ImposterConfig.kt
+++ b/core/api/src/main/java/io/gatehill/imposter/ImposterConfig.kt
@@ -63,8 +63,9 @@ class ImposterConfig {
     var pluginDiscoveryStrategy: PluginDiscoveryStrategy? = null
     var pluginDiscoveryStrategyClass: String? = null
     var useEmbeddedScriptEngine: Boolean = false
+    var soapMode: Boolean = false
 
     override fun toString(): String {
-        return "ImposterConfig(host=$host, listenPort=$listenPort, configDirs=${configDirs.contentToString()}, serverUrl=$serverUrl, isTlsEnabled=$isTlsEnabled, keystorePath=$keystorePath, keystorePassword=$keystorePassword, plugins=${plugins?.contentToString()}, pluginArgs=$pluginArgs, serverFactory=$serverFactory, pluginDiscoveryStrategy=$pluginDiscoveryStrategy, pluginDiscoveryStrategyClass=$pluginDiscoveryStrategyClass, useEmbeddedScriptEngine=$useEmbeddedScriptEngine)"
+        return "ImposterConfig(host=$host, listenPort=$listenPort, configDirs=${configDirs.contentToString()}, serverUrl=$serverUrl, isTlsEnabled=$isTlsEnabled, keystorePath=$keystorePath, keystorePassword=$keystorePassword, plugins=${plugins?.contentToString()}, pluginArgs=$pluginArgs, serverFactory=$serverFactory, pluginDiscoveryStrategy=$pluginDiscoveryStrategy, pluginDiscoveryStrategyClass=$pluginDiscoveryStrategyClass, useEmbeddedScriptEngine=$useEmbeddedScriptEngine, soapMode=$soapMode)"
     }
 }

--- a/core/engine/src/main/java/io/gatehill/imposter/inject/EngineModule.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/inject/EngineModule.kt
@@ -59,6 +59,7 @@ import io.gatehill.imposter.service.ResponseService
 import io.gatehill.imposter.service.ResponseServiceImpl
 import io.gatehill.imposter.service.ScriptedResponseService
 import io.gatehill.imposter.service.SecurityService
+import io.gatehill.imposter.service.SoapAwareUpstreamService
 import io.gatehill.imposter.service.StepService
 import io.gatehill.imposter.service.UpstreamService
 import io.gatehill.imposter.service.script.EmbeddedScriptService
@@ -99,5 +100,6 @@ internal class EngineModule : AbstractModule() {
         bind(RemoteService::class.java).asSingleton()
         bind(StepService::class.java).asSingleton()
         bind(UpstreamService::class.java).asSingleton()
+        bind(SoapAwareUpstreamService::class.java).asSingleton()
     }
 }

--- a/core/engine/src/main/java/io/gatehill/imposter/service/HandlerServiceImpl.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/HandlerServiceImpl.kt
@@ -81,6 +81,8 @@ class HandlerServiceImpl @Inject constructor(
     private val interceptorService: InterceptorService,
     private val responseService: ResponseService,
     private val upstreamService: UpstreamService,
+    private val soapAwareUpstreamService: SoapAwareUpstreamService,
+    private val imposterConfig: ImposterConfig,
 ) : HandlerService, CoroutineScope by supervisedDefaultCoroutineScope {
 
     private val shouldAddEngineResponseHeaders: Boolean =
@@ -339,11 +341,23 @@ class HandlerServiceImpl @Inject constructor(
         pluginConfig: PluginConfig,
         resourceConfig: BasicResourceConfig,
         httpExchange: HttpExchange,
-    ) = upstreamService.forwardToUpstream(
-        pluginConfig as UpstreamsHolder,
-        resourceConfig as PassthroughResourceConfig,
-        httpExchange
-    )
+    ) = if (imposterConfig.soapMode) {
+        // Use SOAP-aware upstream service if SOAP mode is enabled
+        soapAwareUpstreamService.forwardToUpstream(
+            pluginConfig as UpstreamsHolder,
+            resourceConfig as PassthroughResourceConfig,
+            httpExchange,
+            imposterConfig.configDirs.firstOrNull() ?: ".",
+            imposterConfig.soapMode
+        )
+    } else {
+        // Use standard upstream service
+        upstreamService.forwardToUpstream(
+            pluginConfig as UpstreamsHolder,
+            resourceConfig as PassthroughResourceConfig,
+            httpExchange
+        )
+    }
 
     companion object {
         private val LOGGER = LogManager.getLogger(HandlerServiceImpl::class.java)

--- a/core/engine/src/main/java/io/gatehill/imposter/service/SoapAwareUpstreamService.kt
+++ b/core/engine/src/main/java/io/gatehill/imposter/service/SoapAwareUpstreamService.kt
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2023-2024.
+ *
+ * This file is part of Imposter.
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License, as
+ * defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of rights
+ * under the License will not include, and the License does not grant to
+ * you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all of
+ * the rights granted to you under the License to provide to third parties,
+ * for a fee or other consideration (including without limitation fees for
+ * hosting or consulting/support services related to the Software), a
+ * product or service whose value derives, entirely or substantially, from
+ * the functionality of the Software. Any license notice or attribution
+ * required by the License must also include this Commons Clause License
+ * Condition notice.
+ *
+ * Software: Imposter
+ *
+ * License: GNU Lesser General Public License version 3
+ *
+ * Licensor: Peter Cornish
+ *
+ * Imposter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Imposter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Imposter.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.gatehill.imposter.service
+
+import io.gatehill.imposter.exception.ResponseException
+import io.gatehill.imposter.http.HttpExchange
+import io.gatehill.imposter.plugin.config.resource.PassthroughResourceConfig
+import io.gatehill.imposter.plugin.config.resource.UpstreamsHolder
+import io.gatehill.imposter.util.HttpUtil
+import io.gatehill.imposter.util.LogUtil
+import io.gatehill.imposter.util.makeFuture
+import io.vertx.core.buffer.Buffer
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.apache.logging.log4j.LogManager
+import java.io.File
+import java.io.IOException
+import java.net.URI
+import java.util.concurrent.CompletableFuture
+import javax.inject.Inject
+
+/**
+ * Enhanced proxy service that is SOAP-aware and can save requests/responses with SOAPAction-based filenames.
+ * Integrates the implementation of UpstreamService inside
+ * class only used when `--soap` extra argument is used
+ * 
+ * @author Jose Luis
+ */
+class SoapAwareUpstreamService @Inject constructor(
+    private val responseService: ResponseService,
+) {
+    private val logger = LogManager.getLogger(javaClass)
+    private val httpClient = OkHttpClient()
+    
+    /**
+     * Forward a request to an upstream service with SOAP awareness
+     */
+    fun forwardToUpstream(
+        pluginConfig: UpstreamsHolder,
+        resourceConfig: PassthroughResourceConfig,
+        httpExchange: HttpExchange,
+        configDir: String,
+        soapMode: Boolean
+    ): CompletableFuture<Unit> = makeFuture(autoComplete = false) { future ->
+        logger.info("Forwarding ${if (soapMode) "SOAP-aware " else ""}request ${LogUtil.describeRequest(httpExchange)} to upstream ${resourceConfig.passthrough}")
+        val call = buildCall(pluginConfig, resourceConfig, httpExchange)
+        
+        if (logger.isTraceEnabled) {
+            logger.trace("Request to upstream ${resourceConfig.passthrough}: ${call.request()}")
+        }
+        
+        try {
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    logger.error("Failed to forward request ${LogUtil.describeRequest(httpExchange)} to upstream ${call.request().url}", e)
+                    future.completeExceptionally(e)
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (soapMode) {
+                        handleSoapResponse(configDir, resourceConfig, call.request(), response, httpExchange, future)
+                    } else {
+                        handleStandardResponse(resourceConfig, call.request(), response, httpExchange, future)
+                    }
+                }
+            })
+        } catch (e: Exception) {
+            logger.error("Failed to forward request ${LogUtil.describeRequest(httpExchange)} to upstream ${call.request().url}", e)
+            future.completeExceptionally(e)
+        }
+    }
+
+    private fun buildCall(pluginConfig: UpstreamsHolder, resourceConfig: PassthroughResourceConfig, httpExchange: HttpExchange): Call {
+        try {
+            val upstream = pluginConfig.upstreams?.get(resourceConfig.passthrough)
+                ?: throw IllegalStateException("No upstream found for name: ${resourceConfig.passthrough}")
+
+            val requestUri = URI(httpExchange.request.absoluteUri)
+            val upstreamUri = URI(upstream.url)
+
+            val url = URI(
+                upstreamUri.scheme,
+                upstreamUri.userInfo ?: requestUri.userInfo,
+                upstreamUri.host,
+                upstreamUri.port,
+                HttpUtil.joinPaths(upstreamUri.path, requestUri.path),
+                requestUri.query,
+                requestUri.fragment
+            )
+
+            val request = Request.Builder().url(url.toURL()).apply {
+                httpExchange.request.headers.forEach { (name, value) ->
+                    if (name !in skipProxyHeaders) {
+                        addHeader(name, value)
+                    }
+                }
+            }.method(httpExchange.request.method.name, httpExchange.request.body?.bytes?.toRequestBody()).build()
+
+            return httpClient.newCall(request)
+
+        } catch (e: Exception) {
+            throw RuntimeException("Failed to build upstream call for ${LogUtil.describeRequest(httpExchange)}", e)
+        }
+    }
+
+    // same implementation than UpstreamService.handleResponse
+    private fun handleStandardResponse(
+        resourceConfig: PassthroughResourceConfig,
+        request: Request,
+        response: Response,
+        httpExchange: HttpExchange,
+        future: CompletableFuture<Unit>,
+    ) {
+        try {
+            if (logger.isTraceEnabled) {
+                logger.trace("Response from upstream ${resourceConfig.passthrough}: $response")
+            }
+
+            val body = response.body?.string() ?: ""
+            logger.debug(
+                "Received response from upstream ${resourceConfig.passthrough} (${request.url}) with status ${response.code} [body: ${body.length} bytes] for ${LogUtil.describeRequest(httpExchange)}"
+            )
+
+            with(httpExchange.response) {
+                setStatusCode(response.code)
+                response.headers.forEach { (name, value) ->
+                    if (name !in skipProxyHeaders) {
+                        putHeader(name, value)
+                    }
+                }
+            }
+            responseService.sendThenFinaliseExchange(resourceConfig, httpExchange) {
+                try {
+                    responseService.writeResponseData(
+                        resourceConfig,
+                        httpExchange,
+                        filenameHintForContentType = null,
+                        Buffer.buffer(body),
+                        template = false,
+                        trustedData = false
+                    )
+                } catch (e: Exception) {
+                    httpExchange.fail(
+                        ResponseException("Error sending response with status code ${httpExchange.response.statusCode} for ${LogUtil.describeRequest(httpExchange)}", e)
+                    )
+                }
+            }
+            future.complete(Unit)
+
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to handle response from upstream ${resourceConfig.passthrough} (${request.url}) for ${LogUtil.describeRequest(httpExchange)}", e
+            )
+            future.completeExceptionally(e)
+        }
+    }
+
+    private fun handleSoapResponse(
+        configDir: String,
+        resourceConfig: PassthroughResourceConfig,
+        request: Request,
+        response: Response,
+        httpExchange: HttpExchange,
+        future: CompletableFuture<Unit>,
+    ) {
+        try {
+            if (logger.isTraceEnabled) {
+                logger.trace("SOAP response from upstream ${resourceConfig.passthrough}: $response")
+            }
+
+            val body = response.body?.string() ?: ""
+            logger.debug(
+                "Received SOAP response from upstream ${resourceConfig.passthrough} (${request.url}) with status ${response.code} [body: ${body.length} bytes] for ${LogUtil.describeRequest(httpExchange)}"
+            )
+
+            with(httpExchange.response) {
+                setStatusCode(response.code)
+                response.headers.forEach { (name, value) ->
+                    if (name !in skipProxyHeaders) {
+                        putHeader(name, value)
+                    }
+                }
+            }
+            
+            // Extract SOAPAction header for filename generation
+            val soapAction = extractSoapAction(httpExchange)
+            
+            // Save the request and response with SOAPAction-aware filenames
+            saveSoapExchange(configDir, httpExchange, body, soapAction)
+            
+            responseService.sendThenFinaliseExchange(resourceConfig, httpExchange) {
+                try {
+                    responseService.writeResponseData(
+                        resourceConfig,
+                        httpExchange,
+                        filenameHintForContentType = null,
+                        Buffer.buffer(body),
+                        template = false,
+                        trustedData = false
+                    )
+                } catch (e: Exception) {
+                    httpExchange.fail(
+                        ResponseException("Error sending SOAP response with status code ${httpExchange.response.statusCode} for ${LogUtil.describeRequest(httpExchange)}", e)
+                    )
+                }
+            }
+            future.complete(Unit)
+
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to handle SOAP response from upstream ${resourceConfig.passthrough} (${request.url}) for ${LogUtil.describeRequest(httpExchange)}", e
+            )
+            future.completeExceptionally(e)
+        }
+    }
+    
+    /**
+     * Extract the SOAPAction header from the request
+     */
+    fun extractSoapAction(httpExchange: HttpExchange): String? {
+        // Get SOAPAction header - it might be quoted
+        val soapAction = httpExchange.request.headers["SOAPAction"]
+        
+        // Remove quotes if present and return
+        return soapAction?.trim('"')?.takeIf { it.isNotEmpty() }
+    }
+    
+    /**
+     * Generate a filename that incorporates the SOAPAction value
+     */
+    fun generateSoapFilename(baseUrl: String, soapAction: String?, fileType: String): String {
+        val sanitizedUrl = baseUrl.replace(Regex("[^a-zA-Z0-9]"), "_")
+        
+        // If SOAPAction exists, append it to the filename
+        val sanitizedAction = soapAction?.let {
+            "_" + it.replace(Regex("[^a-zA-Z0-9]"), "_")
+        } ?: ""
+        
+        return "${sanitizedUrl}${sanitizedAction}.${fileType}"
+    }
+    
+    /**
+     * Save the SOAP request and response with SOAPAction-aware filenames
+     */
+    fun saveSoapExchange(
+        configDir: String,
+        httpExchange: HttpExchange,
+        responseBody: String,
+        soapAction: String?
+    ) {
+        val requestUrl = httpExchange.request.absoluteUri
+        val path = URI(requestUrl).path
+        
+        // Generate filenames with SOAPAction suffix if present
+        val requestFilename = generateSoapFilename(path, soapAction, "request.xml")
+        val responseFilename = generateSoapFilename(path, soapAction, "response.xml")
+        
+        val configDirFile = File(configDir)
+        if (!configDirFile.exists()) {
+            configDirFile.mkdirs()
+        }
+        
+        // Save request
+        val requestBodyStr = httpExchange.request.body?.toString() ?: ""
+        File(configDirFile, requestFilename).writeText(requestBodyStr)
+        logger.info("Saved SOAP request to: ${requestFilename}")
+        
+        // Save response
+        File(configDirFile, responseFilename).writeText(responseBody)
+        logger.info("Saved SOAP response to: ${responseFilename}")
+        
+        // Generate configuration file that maps this request to its response
+        generateSoapConfigFile(configDirFile, path, responseFilename, soapAction)
+    }
+    
+    /**
+     * Generate an Imposter configuration file for this SOAP operation
+     */
+    fun generateSoapConfigFile(
+        configDir: File,
+        path: String,
+        responseFilename: String,
+        soapAction: String?
+    ) {
+        val configFilename = generateSoapFilename(path, soapAction, "config.yaml")
+        
+        val configContent = if (soapAction != null) {
+            """
+plugin: rest
+path: $path
+resources:
+  - method: POST
+    headers:
+      SOAPAction: "$soapAction"
+    response:
+      file: $responseFilename
+""".trimIndent()
+        } else {
+            """
+plugin: rest
+path: $path
+resources:
+  - method: POST
+    response:
+      file: $responseFilename
+""".trimIndent()
+        }
+        
+        File(configDir, configFilename).writeText(configContent)
+        logger.info("Generated SOAP configuration file: ${configFilename}")
+    }
+    
+    companion object {
+        val skipProxyHeaders = listOf(
+            "Accept-Encoding",
+            "Host",
+
+            // Hop-by-hop headers. These are removed in requests to the upstream or responses to the client.
+            // See "13.5.1 End-to-end and Hop-by-hop Headers" in http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+            "Connection",
+            "Keep-Alive",
+            "Proxy-Authenticate",
+            "Proxy-Authorization",
+            "TE",
+            "Trailers",
+            "Transfer-Encoding",
+            "Upgrade",
+        )
+    }
+}


### PR DESCRIPTION
# SOAP-Aware Proxy Implementation Summary

## Overview

We've successfully implemented a SOAP-aware proxy for Imposter that properly handles SOAP 1.1 services which use the SOAPAction header to differentiate between operations on the same endpoint. 

## Implementation Details

### 1. Enhanced UpstreamService

We created a `SoapAwareUpstreamService` that extends the existing proxy functionality with SOAP awareness:

- Extracts the SOAPAction header from incoming requests
- Generates unique filenames based on the SOAPAction value
- Saves requests and responses with operation-specific names
- Creates configuration files for each SOAP operation

### 2. Configuration Integration

We integrated the SOAP-aware functionality with the existing configuration system:

- Added a `soapMode` flag to `ImposterConfig`
- Added a `--soap` command-line parameter to enable SOAP-aware mode
- Modified the `HandlerServiceImpl` to use the appropriate service based on the mode

### 3. Compatibility

The implementation maintains backward compatibility:

- Standard proxy functionality works as before when `--soap` is not specified
- The SOAP-aware proxy is only used when explicitly enabled
- All existing features continue to work as expected

## Benefits

1. **Operation-specific captures**: Each SOAP operation gets its own request/response pair saved
2. **Automatic configuration**: Generated configuration files include SOAPAction header matching
3. **Organized files**: Clear naming convention makes it easy to identify which files correspond to which operations
4. **Seamless integration**: Works with existing proxy functionality through a command-line flag

## Testing

The implementation has been tested with:

1. Building the project successfully
2. Creating a custom Docker image with the changes
3. Running the container with the SOAP-aware proxy enabled
4. Verifying the command-line parameters work correctly

## Next Steps

1. Add comprehensive tests for the SOAP-aware proxy functionality
2. Enhance error handling and edge cases
3. Add support for SOAP 1.2 which uses Content-Type header instead of SOAPAction
4. Consider adding more configuration options for file naming and organization
